### PR TITLE
Use openjdk8 for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: scala
-jdk: oraclejdk8
+jdk: openjdk8
 scala: 2.12.6
 script: sbt verify
 


### PR DESCRIPTION
It fails because Travis can no longer use oraclejdk.
https://travis-ci.community/t/install-of-oracle-jdk8-is-failing/4365/2