### PR TITLE
[#33] Updating library versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 target
 project/project
+.idea
+.vscode
+.bsp
+.metals

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
-lazy val root = project("paradox-material-theme-parent", file("."))
+lazy val root = (project in file("."))
   .enablePlugins(ParadoxMaterialThemePlugin, GhpagesPlugin, ReleasePlugin)
   .settings(
+    name := "paradox-material-theme-parent",
     addCommandAlias("verify", "; ^sbt-paradox-material-theme/scripted ; makeSite"),
     publish / skip := true,
     releasePublishArtifactsAction := PgpKeys.publishSigned.value,
@@ -81,9 +82,10 @@ lazy val root = project("paradox-material-theme-parent", file("."))
   )
   .aggregate(theme, plugin)
 
-lazy val plugin = project("sbt-paradox-material-theme", file("plugin"))
+lazy val plugin = (project in file("plugin"))
   .enablePlugins(ScriptedPlugin)
   .settings(
+    name := "sbt-paradox-material-theme",
     sbtPlugin := true,
     previewSite := {},
     scriptedLaunchOpts += "-Dproject.version=" + version.value,
@@ -99,9 +101,10 @@ lazy val plugin = project("sbt-paradox-material-theme", file("plugin"))
     }
   )
 
-lazy val theme = project("paradox-material-theme", file("theme"))
+lazy val theme = (project in file("theme"))
   .enablePlugins(ParadoxThemePlugin)
   .settings(
+    name := "paradox-material-theme",
     description := "Material Design theme for Paradox",
     Assets / WebKeys.webJars := {
       val out = (Assets / WebKeys.webJars).value
@@ -196,16 +199,3 @@ lazy val optionExamples = Def.settings(
   }
   //#search-tokenizer
 )
-
-def project(id: String, base: File): Project = {
-  Project(id = id, base = base)
-    .settings(
-      crossSbtVersions := Seq("0.13.18", "1.0.4"),
-      scalaVersion := {
-        (pluginCrossBuild / sbtBinaryVersion).value match {
-          case "0.13" => "2.10.7"
-          case _      => "2.12.8"
-        }
-      }
-  )
-}

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-lazy val root = {project in file(".")}
+lazy val root = (project in file("."))
   .enablePlugins(ParadoxMaterialThemePlugin, GhpagesPlugin, ReleasePlugin)
   .settings(
     name := "paradox-material-theme-parent",
@@ -82,7 +82,7 @@ lazy val root = {project in file(".")}
   )
   .aggregate(theme, plugin)
 
-lazy val plugin = {project in file("plugin")}
+lazy val plugin = (project in file("plugin"))
   .enablePlugins(ScriptedPlugin)
   .settings(
     name := "sbt-paradox-material-theme",
@@ -101,7 +101,7 @@ lazy val plugin = {project in file("plugin")}
     }
   )
 
-lazy val theme = {project in file("theme")}
+lazy val theme = (project in file("theme"))
   .enablePlugins(ParadoxThemePlugin)
   .settings(
     name := "paradox-material-theme",

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-lazy val root = (project in file("."))
+lazy val root = {project in file(".")}
   .enablePlugins(ParadoxMaterialThemePlugin, GhpagesPlugin, ReleasePlugin)
   .settings(
     name := "paradox-material-theme-parent",
@@ -82,7 +82,7 @@ lazy val root = (project in file("."))
   )
   .aggregate(theme, plugin)
 
-lazy val plugin = (project in file("plugin"))
+lazy val plugin = {project in file("plugin")}
   .enablePlugins(ScriptedPlugin)
   .settings(
     name := "sbt-paradox-material-theme",
@@ -101,7 +101,7 @@ lazy val plugin = (project in file("plugin"))
     }
   )
 
-lazy val theme = (project in file("theme"))
+lazy val theme = {project in file("theme")}
   .enablePlugins(ParadoxThemePlugin)
   .settings(
     name := "paradox-material-theme",

--- a/plugin/src/main/scala/io.github.jonas.paradox.material.theme/ParadoxMaterialThemePlugin.scala
+++ b/plugin/src/main/scala/io.github.jonas.paradox.material.theme/ParadoxMaterialThemePlugin.scala
@@ -23,24 +23,24 @@ object ParadoxMaterialThemePlugin extends AutoPlugin {
   )
 
   def paradoxMaterialThemeGlobalSettings: Seq[Setting[_]] = Def.settings(
-    version in paradoxMaterialTheme :=
+    paradoxMaterialTheme / version :=
       Option(ParadoxPlugin.readProperty("paradox-material-theme.properties", "version"))
         .getOrElse(sys.error("Undefined paradox-material-theme version")),
-    paradoxTheme := Some("io.github.jonas" % "paradox-material-theme" % (version in paradoxMaterialTheme).value)
+    paradoxTheme := Some("io.github.jonas" % "paradox-material-theme" % (paradoxMaterialTheme / version).value)
   )
 
   def paradoxMaterialThemeSettings(config: Configuration): Seq[Setting[_]] =
     inConfig(config)(Def.settings(
       paradoxMaterialTheme := ParadoxMaterialTheme(),
-      paradoxProperties += ("material.theme.version" -> (version in paradoxMaterialTheme).value),
+      paradoxProperties += ("material.theme.version" -> (paradoxMaterialTheme / version).value),
       paradoxProperties ++= paradoxMaterialTheme.value.paradoxProperties,
-      mappings in paradoxMaterialTheme := Def.taskDyn {
+      paradoxMaterialTheme / mappings := Def.taskDyn {
         if (paradoxProperties.value.contains("material.search"))
           Def.task(Seq(SearchIndex.mapping(config).value))
         else
           Def.task(Seq.empty[(File, String)])
       }.value,
-      mappings in paradox ++= (mappings in paradoxMaterialTheme).value
+      paradox / mappings ++= (paradoxMaterialTheme / mappings).value
     ))
 
 }

--- a/plugin/src/main/scala/io.github.jonas.paradox.material.theme/SearchIndex.scala
+++ b/plugin/src/main/scala/io.github.jonas.paradox.material.theme/SearchIndex.scala
@@ -12,11 +12,11 @@ import sbt.Keys._
 case class SearchIndex(docs: Seq[SearchIndex.Section])
 
 object SearchIndex {
-  implicit val encoder: ObjectEncoder[SearchIndex] = Encoder.forProduct1("docs")(_.docs)
+  implicit val encoder: Encoder[SearchIndex] = Encoder.forProduct1("docs")(_.docs)
 
   case class Section(location: String, title: String, text: String)
   object Section {
-    implicit val encoder: ObjectEncoder[Section] = Encoder.forProduct3("location", "text", "title")(
+    implicit val encoder: Encoder[Section] = Encoder.forProduct3("location", "text", "title")(
       page => ("/" + page.location, page.text, page.title))
   }
 
@@ -71,8 +71,8 @@ object SearchIndex {
 
   def mapping(scope: Configuration) = Def.task {
     val index = generate(
-      (target in scope).value / "paradox-material-theme",
-      (paradoxMarkdownToHtml in scope).value
+      (scope / target).value / "paradox-material-theme",
+      (scope / paradoxMarkdownToHtml).value
     )
     index -> "search/search_index.json"
   }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.7.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
-addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.4.4")
-addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-theme" % "0.4.4")
-addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.3.2")
-addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.2")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.10.2")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-theme" % "0.10.2")
+addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.3")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
@@ -9,6 +9,6 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 
 // This project is its own plugin :)
-unmanagedSourceDirectories in Compile += baseDirectory.value.getParentFile / "plugin" / "src" / "main" / "scala"
-libraryDependencies += "org.jsoup" % "jsoup" % "1.10.3"
-libraryDependencies += "io.circe" %% "circe-core" % "0.8.0"
+Compile / unmanagedSourceDirectories += baseDirectory.value.getParentFile / "plugin" / "src" / "main" / "scala"
+libraryDependencies += "org.jsoup" % "jsoup" % "1.15.3"
+libraryDependencies += "io.circe" %% "circe-core" % "0.14.3"

--- a/publish.sbt
+++ b/publish.sbt
@@ -20,7 +20,7 @@ inThisBuild(Def.settings(
   // Workaround NPE when publishing: https://github.com/sbt/sbt/issues/3519
   updateOptions := updateOptions.value.withGigahorse(false),
   publishMavenStyle := true,
-  publishArtifact in Test := false,
+  Test / publishArtifact := false,
   pomIncludeRepository := { _ => false },
   publishTo := {
     val nexus = "https://oss.sonatype.org/"


### PR DESCRIPTION
updated libraries, plugins and SBT version (including deprecated syntax warnings).

There does not appear to be any specific reason to support cross building between 2.10 and 2.12 as well as sbt 0.13 being ancient.  I can add this all back in if you would like, it just seemed unnecessary.  