### PR TITLE
Change org to sbt

### DIFF
--- a/plugin/src/main/scala/io.github.jonas.paradox.material.theme/ParadoxMaterialThemePlugin.scala
+++ b/plugin/src/main/scala/io.github.jonas.paradox.material.theme/ParadoxMaterialThemePlugin.scala
@@ -26,7 +26,7 @@ object ParadoxMaterialThemePlugin extends AutoPlugin {
     paradoxMaterialTheme / version :=
       Option(ParadoxPlugin.readProperty("paradox-material-theme.properties", "version"))
         .getOrElse(sys.error("Undefined paradox-material-theme version")),
-    paradoxTheme := Some("io.github.jonas" % "paradox-material-theme" % (paradoxMaterialTheme / version).value)
+    paradoxTheme := Some("com.github.sbt" % "sbt-paradox-material-theme" % (paradoxMaterialTheme / version).value)
   )
 
   def paradoxMaterialThemeSettings(config: Configuration): Seq[Setting[_]] =

--- a/plugin/src/sbt-test/paradox/can-use-theme/project/plugins.sbt
+++ b/plugin/src/sbt-test/paradox/can-use-theme/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("io.github.jonas" % "sbt-paradox-material-theme" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt-paradox-material-theme" % sys.props("project.version"))

--- a/plugin/src/sbt-test/sbt-site/can-use-theme/project/plugins.sbt
+++ b/plugin/src/sbt-test/sbt-site/can-use-theme/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("io.github.jonas" % "sbt-paradox-material-theme" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt-paradox-material-theme" % sys.props("project.version"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.3.1")

--- a/publish.sbt
+++ b/publish.sbt
@@ -1,11 +1,11 @@
 val repo = new {
-  val org = "jonas"
-  val name = "paradox-material-theme"
+  val org = "sbt"
+  val name = "sbt-paradox-material-theme"
   val path = org + "/" + name
 }
 
 inThisBuild(Def.settings(
-  organization := "io.github.jonas",
+  organization := "com.github.sbt",
   licenses += "MIT" -> url("https://github.com/sbt/sbt-paradox-material-theme/blob/master/LICENSE"),
   homepage := Some(url(s"https://${repo.org}.github.io/${repo.name}")),
   scmInfo := Some(

--- a/src/main/paradox/getting-started.md
+++ b/src/main/paradox/getting-started.md
@@ -5,7 +5,7 @@ project's `project/plugins.sbt`:
 
 @@@ vars
 ```sbt
-addSbtPlugin("io.github.jonas" % "sbt-paradox-material-theme" % "$project.version$")
+addSbtPlugin("com.github.sbt" % "sbt-paradox-material-theme" % "$project.version$")
 ```
 @@@
 

--- a/src/main/paradox/index.md
+++ b/src/main/paradox/index.md
@@ -26,7 +26,7 @@ project's `project/plugins.sbt`:
 
 @@@ vars
 ``` sbt
-addSbtPlugin("io.github.jonas" % "sbt-paradox-material-theme" % "$project.version$")
+addSbtPlugin("com.github.sbt" % "sbt-paradox-material-theme" % "$project.version$")
 ```
 @@@
 


### PR DESCRIPTION
This is required to do before changing CI because for some reason in order to even compile the project it is resolving a invalid version of the theme (this will be fixed/resolved in a following PR)