### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# scalafmt
+3b2dc540385d1211bce5c759e27fda9fc320c3eb


### PR DESCRIPTION
Adds `.scalafmt` commit to `.git-blame-ignore-revs`