### PR TITLE
Fix versioning and publishing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,30 +1,8 @@
 lazy val root = project("paradox-material-theme-parent", file("."))
-  .enablePlugins(ParadoxMaterialThemePlugin, GhpagesPlugin, ReleasePlugin)
+  .enablePlugins(ParadoxMaterialThemePlugin, GhpagesPlugin)
   .settings(
     addCommandAlias("verify", "; ^sbt-paradox-material-theme/scripted ; makeSite"),
     publish / skip := true,
-    releasePublishArtifactsAction := PgpKeys.publishSigned.value,
-    releaseTagName := (ThisBuild / version).value,
-    releaseVersionFile := target.value / "unused-version.sbt",
-    releaseProcess := {
-      import ReleaseTransformations._
-      Seq[ReleaseStep](
-        { st: State =>
-          val v = (ThisBuild / version).value
-          st.put(ReleaseKeys.versions, (v, v))
-        },
-        releaseStepTask(makeSite),
-        releaseStepCommandAndRemaining("^test"),
-        releaseStepCommandAndRemaining("^sbt-paradox-material-theme/scripted"),
-        setReleaseVersion,
-        tagRelease,
-        releaseStepCommandAndRemaining("paradox-material-theme/publishSigned"),
-        releaseStepCommandAndRemaining("^sbt-paradox-material-theme/publishSigned"),
-        // FIXME: releaseStepCommand("sonatypeRelease"),
-        pushChanges,
-        releaseStepTask(ghpagesPushSite)
-      )
-    },
     ghpagesNoJekyll := true,
     makeSite / includeFilter := "*.html" | "*.css" | "*.png" | "*.png" | "*.js" | "*.woff" | "*.woff2" | "*.ttf",
     makeSite / mappings ++= (Compile / paradoxMaterialTheme / mappings).value,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,8 @@
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox"       % "0.4.4")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-theme" % "0.4.4")
-addSbtPlugin("com.typesafe.sbt"      % "sbt-site"          % "1.3.2")
-addSbtPlugin("com.typesafe.sbt"      % "sbt-ghpages"       % "0.6.2")
-addSbtPlugin("com.github.gseitz"     % "sbt-release"       % "1.0.6")
-addSbtPlugin("com.jsuereth"          % "sbt-pgp"           % "1.1.0")
+addSbtPlugin("com.github.sbt"        % "sbt-site"          % "1.5.0")
+addSbtPlugin("com.github.sbt"        % "sbt-ghpages"       % "0.8.0")
+addSbtPlugin("com.github.sbt"        % "sbt-ci-release"    % "1.5.12")
 addSbtPlugin("org.xerial.sbt"        % "sbt-sonatype"      % "2.0")
 addSbtPlugin("org.scalameta"         % "sbt-scalafmt"      % "2.5.2")
 

--- a/publish.sbt
+++ b/publish.sbt
@@ -16,32 +16,15 @@ inThisBuild(
       )
     ),
     developers := List(
-      Developer("jonas", "Jonas Fonseca", "jonas.fonseca@gmail.com", url("https://github.com/jonas"))
-    ),
-    // Workaround NPE when publishing: https://github.com/sbt/sbt/issues/3519
-    updateOptions := updateOptions.value.withGigahorse(false),
-    publishMavenStyle := true,
-    Test / publishArtifact := false,
-    pomIncludeRepository := { _ => false },
-    publishTo := {
-      val nexus = "https://oss.sonatype.org/"
-      if (isSnapshot.value)
-        Some("snapshots" at nexus + "content/repositories/snapshots")
-      else
-        Some("releases" at nexus + "service/local/staging/deploy/maven2")
-    },
-    credentials ++= (
-      for {
-        username <- Option(System.getenv().get("SONATYPE_USERNAME"))
-        password <- Option(System.getenv().get("SONATYPE_PASSWORD"))
-      } yield Credentials(
-        "Sonatype Nexus Repository Manager",
-        "oss.sonatype.org",
-        username,
-        password
+      Developer("jonas", "Jonas Fonseca", "jonas.fonseca@gmail.com", url("https://github.com/jonas")),
+      Developer(
+        "sbt-paradox-material-theme",
+        "Sbt Paradox Material Theme Contributors",
+        "",
+        url("https://github.com/sbt/sbt-multi-jvm/graphs/contributors")
       )
-    ).toSeq,
-    versionWithGit,
+    ),
+    dynverSonatypeSnapshots := true,
     git.useGitDescribe := true,
     git.remoteRepo := s"git@github.com:${repo.path}.git"
   )


### PR DESCRIPTION
This PR removes fixes various plugins regarding versioning and plugins (i.e. it replace sbt-dynver with the home grown version of setting version according to git tag).

Most importantly it makes the sbt build load with the new fixed tags (I just renamed the tags from x.x.x to vx.x.x format)