### PR TITLE
Fix update plus compile not working

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -70,6 +70,7 @@ lazy val plugin = project("sbt-paradox-material-theme", file("plugin"))
     addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.4.4"),
     libraryDependencies += "org.jsoup" % "jsoup"      % "1.10.3",
     libraryDependencies += "io.circe" %% "circe-core" % "0.9.3",
+    update := update.dependsOn(theme / publishLocal).value,
     Compile / resourceGenerators += Def.task {
       val file = (Compile / resourceManaged).value / "paradox-material-theme.properties"
       IO.write(file, s"version=${version.value}")

--- a/plugin/src/main/scala/io.github.jonas.paradox.material.theme/ParadoxMaterialThemePlugin.scala
+++ b/plugin/src/main/scala/io.github.jonas.paradox.material.theme/ParadoxMaterialThemePlugin.scala
@@ -26,7 +26,7 @@ object ParadoxMaterialThemePlugin extends AutoPlugin {
     paradoxMaterialTheme / version :=
       Option(ParadoxPlugin.readProperty("paradox-material-theme.properties", "version"))
         .getOrElse(sys.error("Undefined paradox-material-theme version")),
-    paradoxTheme := Some("com.github.sbt" % "sbt-paradox-material-theme" % (paradoxMaterialTheme / version).value)
+    paradoxTheme := Some("com.github.sbt" % "paradox-material-theme" % (paradoxMaterialTheme / version).value)
   )
 
   def paradoxMaterialThemeSettings(config: Configuration): Seq[Setting[_]] =


### PR DESCRIPTION
Resolves: https://github.com/sbt/sbt-paradox-material-theme/issues/43

So I managed to get the project to work as expected, i.e. if I just do `compile` and/or `update` then the project works as expected, without this change you would get

```
[warn] 
[warn] 	Note: Unresolved dependencies path:
[info] compiling 3 Scala sources to /Users/mdedetrich/github/sbt-paradox-material-theme/plugin/target/scala-2.12/sbt-1.0/classes ...
[info] done compiling
[error] stack trace is suppressed; run last update for the full output
[error] (update) sbt.librarymanagement.ResolveException: Error downloading com.github.sbt:sbt-paradox-material-theme:94e451e659676d91adf5f1373b85a271bc9d5442
[error]   Not found
[error]   Not found
[error]   not found: /Users/mdedetrich/.ivy2/local/com.github.sbt/sbt-paradox-material-theme/94e451e659676d91adf5f1373b85a271bc9d5442/ivys/ivy.xml
[error]   not found: https://repo1.maven.org/maven2/com/github/sbt/sbt-paradox-material-theme/94e451e659676d91adf5f1373b85a271bc9d5442/sbt-paradox-material-theme-94e451e659676d91adf5f1373b85a271bc9d5442.pom
[error] Total time: 9 s, completed Feb 5, 2024 12:04:30 PM
```

(as described in the ticket). Without this change you cannot even load the sbt project in Intellij/metals since the `update` task is currently broken.

There were multiple reasons why this was the case, the first one was a trivial error in the `paradoxTheme` org variable. The main problem was due to the `update`, the solution being overriding the `update` task in the `plugin` project so that it depends on `theme / publishLocal`. You will notice that in other parts of `build.sbt` we also had to override tasks such as `compile` so they depend on `theme / publishLocal` but it appears like it was missed in this spot. One thing that has me scratching my head on this solution is why no other sbt-paradox-theme projects seem too have this `update := update.dependsOn(theme / publishLocal).value` workaround, @mkurz @eed3si9n maybe you can shed some light here?

Finally go get everything to work properly I had to implement the dynver adjustment (as is done [here](https://github.com/sbt/sbt-github-actions/blob/main/build.sbt#L50-L65)) so that snapshots always `-SNAPSHOT` otherwise if you have a dirty git state than the project won't compile/update.

In any case with this change the project is compiling successfully/properly which means that we can finally enable CI after this.