### PR TITLE
Use com.github.sbt package and deprecate io.github.jonas

### DIFF
--- a/plugin/src/main/scala/com/github/sbt/paradox/material/theme/ParadoxMaterialTheme.scala
+++ b/plugin/src/main/scala/com/github/sbt/paradox/material/theme/ParadoxMaterialTheme.scala
@@ -1,4 +1,4 @@
-package io.github.jonas.paradox.material.theme
+package com.github.sbt.paradox.material.theme
 
 import java.net.{ URI, URLEncoder }
 import java.util.Locale

--- a/plugin/src/main/scala/com/github/sbt/paradox/material/theme/ParadoxMaterialThemePlugin.scala
+++ b/plugin/src/main/scala/com/github/sbt/paradox/material/theme/ParadoxMaterialThemePlugin.scala
@@ -1,4 +1,4 @@
-package io.github.jonas.paradox.material.theme
+package com.github.sbt.paradox.material.theme
 
 import com.lightbend.paradox.sbt.ParadoxPlugin
 import sbt._
@@ -6,8 +6,8 @@ import sbt.Keys._
 
 object ParadoxMaterialThemePlugin extends AutoPlugin {
   object autoImport {
-    type ParadoxMaterialTheme = _root_.io.github.jonas.paradox.material.theme.ParadoxMaterialTheme
-    val ParadoxMaterialTheme = _root_.io.github.jonas.paradox.material.theme.ParadoxMaterialTheme
+    type ParadoxMaterialTheme = _root_.com.github.sbt.paradox.material.theme.ParadoxMaterialTheme
+    val ParadoxMaterialTheme = _root_.com.github.sbt.paradox.material.theme.ParadoxMaterialTheme
 
     val paradoxMaterialTheme = settingKey[ParadoxMaterialTheme]("Material theme options")
   }

--- a/plugin/src/main/scala/com/github/sbt/paradox/material/theme/SearchIndex.scala
+++ b/plugin/src/main/scala/com/github/sbt/paradox/material/theme/SearchIndex.scala
@@ -1,4 +1,4 @@
-package io.github.jonas.paradox.material.theme
+package com.github.sbt.paradox.material.theme
 
 import scala.collection.JavaConverters._
 import com.lightbend.paradox.sbt.ParadoxPlugin.autoImport.paradoxMarkdownToHtml

--- a/plugin/src/main/scala/io/github/jonas/paradox/material/theme/package.scala
+++ b/plugin/src/main/scala/io/github/jonas/paradox/material/theme/package.scala
@@ -1,0 +1,18 @@
+package io.github.jonas.paradox.material
+
+package object theme {
+  @deprecated("Use com.github.sbt.paradox.material.theme.ParadoxMaterialTheme instead", "0.7.0")
+  val ParadoxMaterialTheme = com.github.sbt.paradox.material.theme.ParadoxMaterialTheme
+
+  @deprecated("Use com.github.sbt.paradox.material.theme.ParadoxMaterialTheme instead", "0.7.0")
+  type ParadoxMaterialTheme = com.github.sbt.paradox.material.theme.ParadoxMaterialTheme
+
+  @deprecated("Use com.github.sbt.paradox.material.theme.ParadoxMaterialThemePlugin instead", "0.7.0")
+  val ParadoxMaterialThemePlugin = com.github.sbt.paradox.material.theme.ParadoxMaterialThemePlugin
+
+  @deprecated("Use com.github.sbt.paradox.material.theme.SearchIndex instead", "0.7.0")
+  val SearchIndex = com.github.sbt.paradox.material.theme.SearchIndex
+
+  @deprecated("Use com.github.sbt.paradox.material.theme.SearchIndex instead", "0.7.0")
+  type SearchIndex = com.github.sbt.paradox.material.theme.SearchIndex
+}


### PR DESCRIPTION
@mkurz So one open point here is about the version to pick for the deprecation warning. Historically we have picked `1.0.0` (i.e. bumping major) but I picked `0.7.0` instead because I want to do a release of sbt-paradox-material-theme against paradox 0.9.x (see https://github.com/lightbend/paradox/issues/601 for reasoning).

After a release of 0.7.0 we can then bump all of the dependencies to their latest respective versions (including the paradox ones) and then release 1.0.0 which is a good time to stabalize this plugin. wdyt?