### PR TITLE
Update dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -73,9 +73,9 @@ lazy val plugin = project("sbt-paradox-material-theme", file("plugin"))
     scriptedLaunchOpts += "-Dproject.version=" + version.value,
     scriptedBufferLog := false,
     publishLocal := publishLocal.dependsOn(theme / publishLocal).value,
-    addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.4.4"),
-    libraryDependencies += "org.jsoup" % "jsoup"      % "1.10.3",
-    libraryDependencies += "io.circe" %% "circe-core" % "0.9.3",
+    addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.9.2"),
+    libraryDependencies += "org.jsoup" % "jsoup"      % "1.17.2",
+    libraryDependencies += "io.circe" %% "circe-core" % "0.14.5",
     update := update.dependsOn(theme / publishLocal).value,
     Compile / resourceGenerators += Def.task {
       val file = (Compile / resourceManaged).value / "paradox-material-theme.properties"

--- a/plugin/src/main/scala/com/github/sbt/paradox/material/theme/SearchIndex.scala
+++ b/plugin/src/main/scala/com/github/sbt/paradox/material/theme/SearchIndex.scala
@@ -12,11 +12,11 @@ import sbt.Keys._
 case class SearchIndex(docs: Seq[SearchIndex.Section])
 
 object SearchIndex {
-  implicit val encoder: ObjectEncoder[SearchIndex] = Encoder.forProduct1("docs")(_.docs)
+  implicit val encoder: Encoder[SearchIndex] = Encoder.forProduct1("docs")(_.docs)
 
   case class Section(location: String, title: String, text: String)
   object Section {
-    implicit val encoder: ObjectEncoder[Section] =
+    implicit val encoder: Encoder[Section] =
       Encoder.forProduct3("location", "text", "title")(page => ("/" + page.location, page.text, page.title))
   }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,8 @@
-addSbtPlugin("com.lightbend.paradox" % "sbt-paradox"        % "0.4.4")
-addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-theme"  % "0.4.4")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox"        % "0.9.2")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-theme"  % "0.9.2")
 addSbtPlugin("com.github.sbt"        % "sbt-site"           % "1.5.0")
 addSbtPlugin("com.github.sbt"        % "sbt-ghpages"        % "0.8.0")
 addSbtPlugin("com.github.sbt"        % "sbt-ci-release"     % "1.5.12")
-addSbtPlugin("org.xerial.sbt"        % "sbt-sonatype"       % "2.0")
 addSbtPlugin("org.scalameta"         % "sbt-scalafmt"       % "2.5.2")
 addSbtPlugin("com.github.sbt"        % "sbt-github-actions" % "0.23.0")
 
@@ -11,5 +10,5 @@ libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 
 // This project is its own plugin :)
 Compile / unmanagedSourceDirectories += baseDirectory.value.getParentFile / "plugin" / "src" / "main" / "scala"
-libraryDependencies += "org.jsoup" % "jsoup"      % "1.10.3"
-libraryDependencies += "io.circe" %% "circe-core" % "0.8.0"
+libraryDependencies += "org.jsoup" % "jsoup"      % "1.17.2"
+libraryDependencies += "io.circe" %% "circe-core" % "0.14.5"


### PR DESCRIPTION
This PR updates dependencies but its also careful to only update to the latest dependencies which still support JDK 8. So for example we are using sbt-paradox/sbt-paradox-theme 0.9.x series which is the latest series that still supports JDK 8