### PR TITLE
Add `SitePreviewPlugin`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbt.internal.inc.Analysis.empty
 
 lazy val root = project("paradox-material-theme-parent", file("."))
-  .enablePlugins(ParadoxMaterialThemePlugin, GhpagesPlugin)
+  .enablePlugins(ParadoxMaterialThemePlugin, SitePreviewPlugin, GhpagesPlugin)
   .settings(
     publish / skip := true,
     ghpagesNoJekyll := true,


### PR DESCRIPTION
See https://www.scala-sbt.org/sbt-site/migration-guide.html

> The `previewSite` plugin does not enable itself anymore, you need to explicitly enable the parts of sbt-site you need on the sbt project/module containing the documentation. To allow `previewSite` with Paradox for example
> ```
> .enablePlugins(SitePreviewPlugin, ParadoxSitePlugin)
> ```