### PR TITLE
[DO-NOT-MERGE] Latest paradox deps test

### DIFF
--- a/plugin/src/sbt-test/paradox/latest-paradox-deps/build.sbt
+++ b/plugin/src/sbt-test/paradox/latest-paradox-deps/build.sbt
@@ -1,0 +1,45 @@
+name := "test"
+
+//#enable-plugin
+enablePlugins(ParadoxMaterialThemePlugin)
+//#enable-plugin
+
+Compile / paradoxProperties ++= Map(
+  "github.base_url" -> "https://github.com/sbt/sbt-paradox-material-theme"
+)
+
+Compile / paradoxMaterialTheme ~= {
+  _.withCopyright("test-copyright")
+    .withLogo("test-logo")
+    .withFavicon("test-favicon")
+}
+
+def fileContains(file: File, texts: String*) = {
+  assert(file.exists, s"${file.getAbsolutePath} did not exist")
+  val content = IO.readLines(file)
+  for (text <- texts)
+    assert(
+      content.exists(_.contains(text)),
+      s"Did not find '$text' in ${file.getName}:\n${content.mkString("\n")}"
+    )
+}
+
+TaskKey[Unit]("checkContent") := {
+  val dest = (Compile / paradox / target).value
+
+  fileContains(
+    dest / "index.html",
+    "Paradox Site",
+    "Nicely themed",
+    "mkdocs-material",
+    "test-copyright",
+    "test-logo",
+    "test-favicon"
+  )
+
+  fileContains(
+    dest / "search" / "search_index.json",
+    "Paradox Site",
+    "Nicely themed"
+  )
+}

--- a/plugin/src/sbt-test/paradox/latest-paradox-deps/project/plugins.sbt
+++ b/plugin/src/sbt-test/paradox/latest-paradox-deps/project/plugins.sbt
@@ -1,0 +1,8 @@
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox"       % "0.10.6")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-theme" % "0.10.6")
+
+sys.props.get("project.version") match {
+  case Some(x) => addSbtPlugin("com.github.sbt" % "sbt-paradox-material-theme" % x)
+  case _ => sys.error("""|The system property 'project.version' is not defined.
+                               |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/plugin/src/sbt-test/paradox/latest-paradox-deps/src/main/paradox/index.md
+++ b/plugin/src/sbt-test/paradox/latest-paradox-deps/src/main/paradox/index.md
@@ -1,0 +1,3 @@
+# Paradox Site
+
+Nicely themed.

--- a/plugin/src/sbt-test/paradox/latest-paradox-deps/test
+++ b/plugin/src/sbt-test/paradox/latest-paradox-deps/test
@@ -1,0 +1,2 @@
+> paradox
+> checkContent


### PR DESCRIPTION
This PR is just here to demonstrate what is said [here](https://github.com/sbt/sbt-paradox-material-theme/issues/59#issuecomment-1943577195), specifically that even though sbt-paradox-material-theme may be compiled against sbt-paradox/sbt-paradox-theme 0.9.2, it will work completely fine with sbt-paradox/sbt-paradox-theme 0.10.6

In order to demonstrate this, check out the PR's branch and make sure to set JDK to 11 (since sbt-paradox/sbt-paradox-theme 0.10.6 only supports JDK 11+) and run the following command

```
sbt "sbt-paradox-material-theme/scripted paradox/latest-paradox-deps"
```

Ideally we would actually add this as a scripted test to the repo but unfortunately there isn't an easy way to do this since the rest of the tests only run on JDK 8 and this scripted test needs to be run with JDK 11 specifically (this is why the CI is failing)
