### PR TITLE
Add instructions for different JDK usage

### DIFF
--- a/src/main/paradox/getting-started.md
+++ b/src/main/paradox/getting-started.md
@@ -3,8 +3,20 @@
 In order to enable the theme add the following line to your
 project's `project/plugins.sbt`:
 
+## JDK 1.8
+
 @@@ vars
 ```sbt
+addSbtPlugin("com.github.sbt" % "sbt-paradox-material-theme" % "$project.version$")
+```
+@@@
+
+## JDK 11+
+
+@@@ vars
+```sbt
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.10.6")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-theme" % "0.10.6")
 addSbtPlugin("com.github.sbt" % "sbt-paradox-material-theme" % "$project.version$")
 ```
 @@@


### PR DESCRIPTION
Related to https://github.com/sbt/sbt-paradox-material-theme/issues/59#issuecomment-1943577195 and https://github.com/sbt/sbt-paradox-material-theme/pull/67