### PR TITLE
Pin sbt-paradox/sbt-paradox-theme to 0.9.x

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,3 +1,5 @@
 updates.pin = [
   { groupId = "org.scala-lang", artifactId = "scala-library", version = "2.12." }
+  { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox", version = "0.9." }
+  { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox-theme", version = "0.9." }
 ]


### PR DESCRIPTION
See https://github.com/sbt/sbt-paradox-material-theme/issues/59#issuecomment-1943577195 for context. When we are forced to update to sbt-paradox/sbt-paradox-theme 0.10.x (or later) then we can remove these pinned dependencies.

After this scala-steward can be enabled for the repo